### PR TITLE
fixes open_fifo reading to far on the path slice

### DIFF
--- a/src/mkfifo.rs
+++ b/src/mkfifo.rs
@@ -14,7 +14,7 @@ pub fn open_fifo(path: &Path) -> Option<File> {
             _ => None, // regular file
         },
         _ => {
-            let path_ptr = path.to_str().unwrap().as_ptr();
+            let path_ptr = path.as_os_str().to_os_string().to_str().unwrap().as_ptr();
             let perms = libc::S_IRUSR | libc::S_IWUSR;
             let ret = unsafe {
                 libc::mkfifo(path_ptr as *const i8, perms)


### PR DESCRIPTION
In my case `open_fifo` tried to create a fifo at `/tmp/cccac_fifo temperature`, not `/tmp/cccac_fifo`.
